### PR TITLE
Feature/esds doc 12  tint stack

### DIFF
--- a/components/tint_stack/tint_stack.njk
+++ b/components/tint_stack/tint_stack.njk
@@ -1,76 +1,64 @@
 {% macro tint_stack(
             class=false,
-            swatches=[
-                '#656565',
-                {
-                    hex: '#123456',
-                    label: 'Mystery Color'
-                },
-                {
-                    hex: '#F57026',
-                    label: 'Orange Light',
-                    accessibility_score: 'AA',
-                    show_contrast_ratio: true
-                },
-                {
-                    hex: '#0A9DB3',
-                    label: 'Blue Light',
-                    code_snippet: '$esds-doc-color-blue-light'
-                },
-                {
-                    hex: '#262626',
-                    label: 'Background Color Dark',
-                    contrast_test_color: '#f3f1f1',
-                    code_snippet: '$esds-doc-background-color-dark',
-                    color_role: 'background'
-                },
-                {
-                    hex: '#000000',
-                    label: 'Text Color Primary, On White',
-                    contrast_test_color: '#ffffff',
-                    code_snippet: '$esds-doc-text-color-primary-on-white',
-                    color_role: 'foreground',
-                    show_border: true
-                },
-                {
-                    hex: '#888888',
-                    label: 'Border Separator, On Dark',
-                    contrast_test_color: '#262626',
-                    code_snippet: '$esds-doc-border-separator-on-dark',
-                    html_example: '<span style="border-bottom: solid 1px #888888; width: 180px; display: inline-block; vertical-align: middle;"></span>',
-                    show_hex: false,
-                    color_role: 'foreground'
-                },
-                {
-                    hex: '#068194',
-                    label: 'Special Class for this swatch',
-                    class: 'my-special-tint-stack-swatch-class',
-                    code_snippet: '$esds-doc-border-separator-on-dark'
-                },
-                {
-                    hex: '#FFFFFF',
-                    show_border: true
-                }
-            ]) %}
+            swatches=[],
+            show_documentation=false) %}
     <div class="esds-doc-tint-stack{{ ' ' + class }}">
-        {% for swatch in swatches %}
-            {% if swatch[0] %}
-                {# Swatch values are just a string, render basic swatch #}
-                {{ tint_stack_swatch(hex=swatch) }}
-            {% else %}
-                {{ tint_stack_swatch(class=swatch.class,
-                                        hex=swatch.hex,
-                                        label=swatch.label,
-                                        accessibility_score=swatch.accessibility_score,
-                                        code_snippet=swatch.code_snippet,
-                                        contrast_test_color=swatch.contrast_test_color,
-                                        color_role=swatch.color_role,
-                                        html_example=swatch.html_example,
-                                        show_border=swatch.show_border,
-                                        show_hex=swatch.show_hex,
-                                        show_contrast_ratio=swatch.show_contrast_ratio) }}
-            {% endif %}
-        {% endfor %}
+        {% if swatches.length == 0 or show_documentation %}
+            {# If no swatches are passed in or the show_documentation variable is set to true, show API documentation #}
+            <div class="esds-doc-tint-stack__empty-state-documentation">
+                {% filter markdown %}
+                    ### Tint Stack API
+                {% endfilter %}
+                {% set tint_stack_api_source %}
+                    {% raw %}
+                    {{ esds_doc.tint_stack(
+                        class='my-class',                                           // Space-separated classes passed as a string, will be added to the top-level block of the component
+                        show_documentation: true | false (default)                  // Show this API documentation
+                        swatches=[
+                            {
+                                hex: '#123456',                                     // Any hex color
+                                label: 'Name of this color',                        // Label for the color, if none provided the hex value will be used,
+                                accessibility_score: 'AAA' | undefined | false,     // Shown as a pill on the tint swatch, if not provided this will be calculated automatically, if false, no pill will be shown 
+                                code_snippet: '$name-of-color-token',               // Shown as a code block pill if provided
+                                contrast_test_color: undefined | '#123456',         // If not provided, 'hex' will be tested against both #000000 and #FFFFFF and the highest contrast ratio will be used to calculate 'accessibility_score', if provided, this will be tested against 'hex' to determine the 'accessibility_score'
+                                color_role: 'foreground' | 'background',            // determines if 'hex' is the background color of the swatch ('background') or the text color of the swatch ('foreground'). 'contrast_test_color' will be used opposite the 'color_role' setting, either as background color or text color
+                                html_example: '<span class="anything"></span>',     // renders int he swatch after the label, useful for showing html-based examples like border colors
+                                show_border: true | false (default),                // If true, the tint swatch will have a border drawn around it. Useful if the background of the swatch is the same color as the page background
+                                show_hex: true (default) | false,                   // If true, suppresses the 'hex' pill in the swatch, 'hex' pill is automatically suppressed when no 'label' is provided
+                                show_contrast_ratio: true | false (default)         // If true, renders the calculated contrast ratio inside the 'accessibility_score' pill, alongside the accessibility score
+                            }
+                        ]
+                     )}}
+
+                     {# alternatively, the tint_stack can be invoked with just an array of hex codes #}
+                     {# This syntax will cause the hex codes to be used as labels and automatically calculate the accessibility score #}
+
+                     {{ esds_doc.tint_stack(swatches=['#123456', '#7890AB', '#CDEF01']) }}
+                     
+                    {% endraw %}                   
+                {% endset %}
+                {{ code_snippet(class='esds-doc-code-snippet--no-max-height', source=tint_stack_api_source, preformatted=true, language='njk') }}
+            </div>
+        {% else %}
+            {% for swatch in swatches %}
+                {% if swatch[0] %}
+                    {# Swatch values are just a string, render basic swatch #}
+                    {{ tint_stack_swatch(hex=swatch) }}
+                {% else %}
+                    {{ tint_stack_swatch(class=swatch.class,
+                                            hex=swatch.hex,
+                                            label=swatch.label,
+                                            accessibility_score=swatch.accessibility_score,
+                                            code_snippet=swatch.code_snippet,
+                                            contrast_test_color=swatch.contrast_test_color,
+                                            color_role=swatch.color_role,
+                                            html_example=swatch.html_example,
+                                            show_border=swatch.show_border,
+                                            show_hex=swatch.show_hex,
+                                            show_contrast_ratio=swatch.show_contrast_ratio) }}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
     </div>
 {% endmacro %}
 
@@ -109,15 +97,17 @@
         {% set background_color = hex %}
     {% endif %}
 
-    {% set contrast_ratio = foreground_color | getContrastRatioForHex(background_color) %}
-    {% set accessibility_score = contrast_ratio %}
-    {% set accessibility_score_label = "DNP" %}
-    {% if contrast_ratio >= 7.0 %}
-        {% set accessibility_score_label = "AAA" %}
-    {% elif contrast_ratio >= 4.5 %}
-        {% set accessibility_score_label = "AA" %}
-    {% elif contrast_ratio >= 3.0 %}
-        {% set accessibility_score_label = "AA18" %}
+    {% if accessibility_score != false %}
+        {% set contrast_ratio = foreground_color | getContrastRatioForHex(background_color) %}
+        {% set accessibility_score = contrast_ratio %}
+        {% set accessibility_score_label = "DNP" %}
+        {% if contrast_ratio >= 7.0 %}
+            {% set accessibility_score_label = "AAA" %}
+        {% elif contrast_ratio >= 4.5 %}
+            {% set accessibility_score_label = "AA" %}
+        {% elif contrast_ratio >= 3.0 %}
+            {% set accessibility_score_label = "AA18" %}
+        {% endif %}
     {% endif %}
 
     <div class="esds-doc-tint-stack__swatch{{ ' ' + class if class }}{{ ' esds-doc-tint-stack__swatch--with-border' if show_border }}" style="background-color: {{ background_color }}; color: {{ foreground_color }};">
@@ -135,13 +125,15 @@
                     {{- code_snippet -}}
                 </span>
             {% endif %}
-            {% if show_hex %}
+            {% if show_hex and hex != label %}
                 <span class="esds-doc-tint-stack__pill esds-doc-tint-stack__pill--hex">
                     {{- hex -}}
                 </span>
             {% endif %}
             {% if accessibility_score %}
-                <span class="esds-doc-tint-stack__pill esds-doc-tint-stack__pill--accessibility-score">
+
+                {% set accessibility_score_class = 'esds-doc-tint-stack__pill--accessibility-score-' + accessibility_score_label | lower %}
+                <span class="esds-doc-tint-stack__pill esds-doc-tint-stack__pill--accessibility-score {{ accessibility_score_class }}">
                     {{- accessibility_score_label -}}
                     {{- ', ' + contrast_ratio if show_contrast_ratio -}}
                 </span>

--- a/components/tint_stack/tint_stack.njk
+++ b/components/tint_stack/tint_stack.njk
@@ -1,7 +1,7 @@
 {% macro tint_stack(
             class=false,
             swatches=[
-                '#FFFFFF',
+                '#656565',
                 {
                     hex: '#123456',
                     label: 'Mystery Color'
@@ -9,7 +9,8 @@
                 {
                     hex: '#F57026',
                     label: 'Orange Light',
-                    accessibility_score: 'AA'
+                    accessibility_score: 'AA',
+                    show_contrast_ratio: true
                 },
                 {
                     hex: '#0A9DB3',
@@ -28,14 +29,15 @@
                     label: 'Text Color Primary, On White',
                     contrast_test_color: '#ffffff',
                     code_snippet: '$esds-doc-text-color-primary-on-white',
-                    color_role: 'foreground'
+                    color_role: 'foreground',
+                    show_border: true
                 },
                 {
                     hex: '#888888',
                     label: 'Border Separator, On Dark',
                     contrast_test_color: '#262626',
                     code_snippet: '$esds-doc-border-separator-on-dark',
-                    html_example: '<span style="border-bottom: solid 1px #262626; width: 100px; display: inline-block;"></span>',
+                    html_example: '<span style="border-bottom: solid 1px #888888; width: 180px; display: inline-block; vertical-align: middle;"></span>',
                     show_hex: false,
                     color_role: 'foreground'
                 },
@@ -43,8 +45,11 @@
                     hex: '#068194',
                     label: 'Special Class for this swatch',
                     class: 'my-special-tint-stack-swatch-class',
-                    contrast_test_color: '#262626',
                     code_snippet: '$esds-doc-border-separator-on-dark'
+                },
+                {
+                    hex: '#FFFFFF',
+                    show_border: true
                 }
             ]) %}
     <div class="esds-doc-tint-stack{{ ' ' + class }}">
@@ -62,7 +67,8 @@
                                         color_role=swatch.color_role,
                                         html_example=swatch.html_example,
                                         show_border=swatch.show_border,
-                                        show_hex=swatch.show_hex) }}
+                                        show_hex=swatch.show_hex,
+                                        show_contrast_ratio=swatch.show_contrast_ratio) }}
             {% endif %}
         {% endfor %}
     </div>
@@ -77,27 +83,45 @@
                             color_role, 
                             html_example,
                             show_border,
-                            show_hex) %}
+                            show_hex,
+                            show_contrast_ratio) %}
     {% set show_hex = show_hex | default(true) %}
     {% set label = label | default(hex) %}
-    {% set foreground_color = "#000000" %}
-    {% set background_color = hex %}
     {% set color_role = color_role | default('background') %}
     
-    {% if color_role == 'foreground' and contrast_test_color %}
-        {% set background_color = contrast_test_color %}
+    {# If no contrast_test_color is provided, check the contrast against white and the contrast against black, #}
+    {# Use whichever color has a higher contrast ratio for the accessibility_score and alternate color #}
+    {% if not contrast_test_color %}
+        {% set white_contrast = hex | getContrastRatioForHex("#FFFFFF") %}
+        {% set black_contrast = hex | getContrastRatioForHex("#000000") %}
+        {% if white_contrast > black_contrast %}
+            {% set contrast_test_color = "#FFFFFF" %}
+        {% else %}
+            {% set contrast_test_color = "#000000" %}
+        {% endif %}
+    {% endif %}
+
+    {% if color_role == 'foreground' %}
         {% set foreground_color = hex %}
+        {% set background_color = contrast_test_color %}
+    {% else %}
+        {% set foreground_color = contrast_test_color %}
+        {% set background_color = hex %}
     {% endif %}
 
     {% set contrast_ratio = foreground_color | getContrastRatioForHex(background_color) %}
-
-    {% if contrast_ratio < 12 and not contrast_test_color %}
-        {% set foreground_color = "#ffffff" %}
+    {% set accessibility_score = contrast_ratio %}
+    {% set accessibility_score_label = "DNP" %}
+    {% if contrast_ratio >= 7.0 %}
+        {% set accessibility_score_label = "AAA" %}
+    {% elif contrast_ratio >= 4.5 %}
+        {% set accessibility_score_label = "AA" %}
+    {% elif contrast_ratio >= 3.0 %}
+        {% set accessibility_score_label = "AA18" %}
     {% endif %}
 
-    <div class="esds-doc-tint-stack__swatch{{ ' ' + class if class }}{{ ' esds-doc-tint-stack__swatch--with-border' if show_border }}" style="background-color: {{ background_color }};">
-        {{ contrast_ratio }}
-        <span class="esds-doc-tint-stack__label" style="color: {{ foreground_color }};">
+    <div class="esds-doc-tint-stack__swatch{{ ' ' + class if class }}{{ ' esds-doc-tint-stack__swatch--with-border' if show_border }}" style="background-color: {{ background_color }}; color: {{ foreground_color }};">
+        <span class="esds-doc-tint-stack__label">
             {{ label }}
         </span>
         {% if html_example %}
@@ -105,20 +129,23 @@
                 {{ html_example | safe }}
             </span>
         {% endif %}
-        {% if code_snippet %}
-            <span class="esds-doc-tint-stack__pill esds-doc-tint-stack__pill--code-snippet">
-                {{ code_snippet }}
-            </span>
-        {% endif %}
-        {% if show_hex %}
-            <span class="esds-doc-tint-stack__pill esds-doc-tint-stack__pill--hex">
-                {{ hex }}
-            </span>
-        {% endif %}
-        {% if accessibility_score %}
-            <span class="esds-doc-tint-stack__pill esds-doc-tint-stack__pill--accessibility-score">
-                {{ accessibility_score }}
-            </span>
-        {% endif %}
+        <span class="esds-doc-tint-stack__swatch-metadata">
+            {% if code_snippet %}
+                <span class="esds-doc-tint-stack__pill esds-doc-tint-stack__pill--code-snippet">
+                    {{- code_snippet -}}
+                </span>
+            {% endif %}
+            {% if show_hex %}
+                <span class="esds-doc-tint-stack__pill esds-doc-tint-stack__pill--hex">
+                    {{- hex -}}
+                </span>
+            {% endif %}
+            {% if accessibility_score %}
+                <span class="esds-doc-tint-stack__pill esds-doc-tint-stack__pill--accessibility-score">
+                    {{- accessibility_score_label -}}
+                    {{- ', ' + contrast_ratio if show_contrast_ratio -}}
+                </span>
+            {% endif %}
+        </span>
     </div>
 {% endmacro %}

--- a/components/tint_stack/tint_stack.njk
+++ b/components/tint_stack/tint_stack.njk
@@ -1,8 +1,8 @@
 {% macro tint_stack(
-            class=false,
+            class,
             swatches=[],
             show_documentation=false) %}
-    <div class="esds-doc-tint-stack{{ ' ' + class }}">
+    <div class="esds-doc-tint-stack{{ ' ' + class if class }}">
         {% if swatches.length == 0 or show_documentation %}
             {# If no swatches are passed in or the show_documentation variable is set to true, show API documentation #}
             <div class="esds-doc-tint-stack__empty-state-documentation">

--- a/components/tint_stack/tint_stack.njk
+++ b/components/tint_stack/tint_stack.njk
@@ -16,10 +16,13 @@
                         show_documentation: true | false (default)                  // Show this API documentation
                         swatches=[
                             {
-                                hex: '#123456',                                     // Any hex color
+                                hex: '#123456' (required),                          // Any hex color
                                 label: 'Name of this color',                        // Label for the color, if none provided the hex value will be used,
+                                label_color: '#123456' | 'automatic',               // Override the text color of the label with a hex code, or, if 'automatic' is passed in, the highest contrast of #000000 or #FFFFFF against the background color will be used
                                 accessibility_score: 'AAA' | undefined | false,     // Shown as a pill on the tint swatch, if not provided this will be calculated automatically, if false, no pill will be shown 
                                 code_snippet: '$name-of-color-token',               // Shown as a code block pill if provided
+                                code_snippets: ['$name-of-color-token', 
+                                                'solid 1px #123456'],               // Array of code blocks, each shown as a pill
                                 contrast_test_color: undefined | '#123456',         // If not provided, 'hex' will be tested against both #000000 and #FFFFFF and the highest contrast ratio will be used to calculate 'accessibility_score', if provided, this will be tested against 'hex' to determine the 'accessibility_score'
                                 color_role: 'foreground' | 'background',            // determines if 'hex' is the background color of the swatch ('background') or the text color of the swatch ('foreground'). 'contrast_test_color' will be used opposite the 'color_role' setting, either as background color or text color
                                 html_example: '<span class="anything"></span>',     // renders int he swatch after the label, useful for showing html-based examples like border colors
@@ -48,8 +51,10 @@
                     {{ tint_stack_swatch(class=swatch.class,
                                             hex=swatch.hex,
                                             label=swatch.label,
+                                            label_color=swatch.label_color,
                                             accessibility_score=swatch.accessibility_score,
                                             code_snippet=swatch.code_snippet,
+                                            code_snippets=swatch.code_snippets,
                                             contrast_test_color=swatch.contrast_test_color,
                                             color_role=swatch.color_role,
                                             html_example=swatch.html_example,
@@ -65,8 +70,10 @@
 {% macro tint_stack_swatch(class,
                             hex, 
                             label, 
+                            label_color, 
                             accessibility_score, 
                             code_snippet, 
+                            code_snippets, 
                             contrast_test_color, 
                             color_role, 
                             html_example,
@@ -84,8 +91,10 @@
         {% set black_contrast = hex | getContrastRatioForHex("#000000") %}
         {% if white_contrast > black_contrast %}
             {% set contrast_test_color = "#FFFFFF" %}
+            {% set automatic_label_color = "#FFFFFF" %}
         {% else %}
             {% set contrast_test_color = "#000000" %}
+            {% set automatic_label_color = "#000000" %}
         {% endif %}
     {% endif %}
 
@@ -110,8 +119,10 @@
         {% endif %}
     {% endif %}
 
+    {% set label_color = label_color | default(foreground_color) %}
+
     <div class="esds-doc-tint-stack__swatch{{ ' ' + class if class }}{{ ' esds-doc-tint-stack__swatch--with-border' if show_border }}" style="background-color: {{ background_color }}; color: {{ foreground_color }};">
-        <span class="esds-doc-tint-stack__label">
+        <span class="esds-doc-tint-stack__label" style="color: {{ label_color }}">
             {{ label }}
         </span>
         {% if html_example %}
@@ -124,6 +135,13 @@
                 <span class="esds-doc-tint-stack__pill esds-doc-tint-stack__pill--code-snippet">
                     {{- code_snippet -}}
                 </span>
+            {% endif %}
+            {% if code_snippets %}
+                {% for snippet in code_snippets %}
+                    <span class="esds-doc-tint-stack__pill esds-doc-tint-stack__pill--code-snippet">
+                        {{- snippet -}}
+                    </span>
+                {% endfor %}
             {% endif %}
             {% if show_hex and hex != label %}
                 <span class="esds-doc-tint-stack__pill esds-doc-tint-stack__pill--hex">

--- a/components/tint_stack/tint_stack.njk
+++ b/components/tint_stack/tint_stack.njk
@@ -1,0 +1,124 @@
+{% macro tint_stack(
+            class=false,
+            swatches=[
+                '#FFFFFF',
+                {
+                    hex: '#123456',
+                    label: 'Mystery Color'
+                },
+                {
+                    hex: '#F57026',
+                    label: 'Orange Light',
+                    accessibility_score: 'AA'
+                },
+                {
+                    hex: '#0A9DB3',
+                    label: 'Blue Light',
+                    code_snippet: '$esds-doc-color-blue-light'
+                },
+                {
+                    hex: '#262626',
+                    label: 'Background Color Dark',
+                    contrast_test_color: '#f3f1f1',
+                    code_snippet: '$esds-doc-background-color-dark',
+                    color_role: 'background'
+                },
+                {
+                    hex: '#000000',
+                    label: 'Text Color Primary, On White',
+                    contrast_test_color: '#ffffff',
+                    code_snippet: '$esds-doc-text-color-primary-on-white',
+                    color_role: 'foreground'
+                },
+                {
+                    hex: '#888888',
+                    label: 'Border Separator, On Dark',
+                    contrast_test_color: '#262626',
+                    code_snippet: '$esds-doc-border-separator-on-dark',
+                    html_example: '<span style="border-bottom: solid 1px #262626; width: 100px; display: inline-block;"></span>',
+                    show_hex: false,
+                    color_role: 'foreground'
+                },
+                {
+                    hex: '#068194',
+                    label: 'Special Class for this swatch',
+                    class: 'my-special-tint-stack-swatch-class',
+                    contrast_test_color: '#262626',
+                    code_snippet: '$esds-doc-border-separator-on-dark'
+                }
+            ]) %}
+    <div class="esds-doc-tint-stack{{ ' ' + class }}">
+        {% for swatch in swatches %}
+            {% if swatch[0] %}
+                {# Swatch values are just a string, render basic swatch #}
+                {{ tint_stack_swatch(hex=swatch) }}
+            {% else %}
+                {{ tint_stack_swatch(class=swatch.class,
+                                        hex=swatch.hex,
+                                        label=swatch.label,
+                                        accessibility_score=swatch.accessibility_score,
+                                        code_snippet=swatch.code_snippet,
+                                        contrast_test_color=swatch.contrast_test_color,
+                                        color_role=swatch.color_role,
+                                        html_example=swatch.html_example,
+                                        show_border=swatch.show_border,
+                                        show_hex=swatch.show_hex) }}
+            {% endif %}
+        {% endfor %}
+    </div>
+{% endmacro %}
+
+{% macro tint_stack_swatch(class,
+                            hex, 
+                            label, 
+                            accessibility_score, 
+                            code_snippet, 
+                            contrast_test_color, 
+                            color_role, 
+                            html_example,
+                            show_border,
+                            show_hex) %}
+    {% set show_hex = show_hex | default(true) %}
+    {% set label = label | default(hex) %}
+    {% set foreground_color = "#000000" %}
+    {% set background_color = hex %}
+    {% set color_role = color_role | default('background') %}
+    
+    {% if color_role == 'foreground' and contrast_test_color %}
+        {% set background_color = contrast_test_color %}
+        {% set foreground_color = hex %}
+    {% endif %}
+
+    {% set contrast_ratio = foreground_color | getContrastRatioForHex(background_color) %}
+
+    {% if contrast_ratio < 12 and not contrast_test_color %}
+        {% set foreground_color = "#ffffff" %}
+    {% endif %}
+
+    <div class="esds-doc-tint-stack__swatch{{ ' ' + class if class }}{{ ' esds-doc-tint-stack__swatch--with-border' if show_border }}" style="background-color: {{ background_color }};">
+        {{ contrast_ratio }}
+        <span class="esds-doc-tint-stack__label" style="color: {{ foreground_color }};">
+            {{ label }}
+        </span>
+        {% if html_example %}
+            <span class="esds-doc-tint-stack__html-example">
+                {{ html_example | safe }}
+            </span>
+        {% endif %}
+        {% if code_snippet %}
+            <span class="esds-doc-tint-stack__pill esds-doc-tint-stack__pill--code-snippet">
+                {{ code_snippet }}
+            </span>
+        {% endif %}
+        {% if show_hex %}
+            <span class="esds-doc-tint-stack__pill esds-doc-tint-stack__pill--hex">
+                {{ hex }}
+            </span>
+        {% endif %}
+        {% if accessibility_score %}
+            <span class="esds-doc-tint-stack__pill esds-doc-tint-stack__pill--accessibility-score">
+                {{ accessibility_score }}
+            </span>
+        {% endif %}
+    </div>
+{% endmacro %}

--- a/components/tint_stack/tint_stack.scss
+++ b/components/tint_stack/tint_stack.scss
@@ -15,7 +15,14 @@ $esds-doc-tint-stack-pill-min-width: 4em !default;
 
 $esds-doc-tint-stack-html-example-space-inline: $esds-doc-space-generic-1-x !default;
 
-$esds-doc-tint-stack-label-max-width: none;
+$esds-doc-tint-stack-label-max-width: none !default;
+
+$esds-doc-tint-stack-aa18-pill-background-color: #CFB317 !default;
+$esds-doc-tint-stack-aa18-pill-text-color: $esds-doc-text-color-primary-on-white !default;
+
+$esds-doc-tint-stack-dnp-pill-background-color: #EE0000 !default;
+$esds-doc-tint-stack-dnp-pill-text-color: $esds-doc-text-color-primary-on-black !default;
+
 
 .esds-doc-tint-stack {
     @include esds-doc-box-sizing;
@@ -23,9 +30,15 @@ $esds-doc-tint-stack-label-max-width: none;
         $font-family: $esds-doc-tint-stack-font-family);
 }
 
+.esds-doc-tint-stack__empty-state-documentation {
+    @include esds-doc-font-reset;
+    color: $esds-doc-text-color-primary-on-white;
+}
+
 .esds-doc-tint-stack__swatch {
     align-items: center;
     display: flex;
+    flex-wrap: wrap;
     padding: $esds-doc-tint-stack-space-swatch-inset;
 }
 
@@ -44,6 +57,16 @@ $esds-doc-tint-stack-label-max-width: none;
     min-width: $esds-doc-tint-stack-pill-min-width;
     padding: $esds-doc-tint-stack-pill-space-inset;
     text-align: $esds-doc-tint-stack-pill-text-align;
+}
+
+.esds-doc-tint-stack__pill--accessibility-score-aa18 {
+    background-color: $esds-doc-tint-stack-aa18-pill-background-color;
+    color: $esds-doc-tint-stack-aa18-pill-text-color;
+}
+
+.esds-doc-tint-stack__pill--accessibility-score-dnp {
+    background-color: $esds-doc-tint-stack-dnp-pill-background-color;
+    color: $esds-doc-tint-stack-dnp-pill-text-color;
 }
 
 .esds-doc-tint-stack__swatch-metadata {

--- a/components/tint_stack/tint_stack.scss
+++ b/components/tint_stack/tint_stack.scss
@@ -1,0 +1,59 @@
+$esds-doc-tint-stack-font-family: $esds-doc-font-family-sans-serif !default;
+$esds-doc-tint-stack-space-swatch-inset: $esds-doc-space-inset-1-x !default;
+
+$esds-doc-tint-stack-swatch-border: $esds-doc-border-separator-default !default;
+
+$esds-doc-tint-stack-pill-background-color: $esds-doc-background-color-light !default;
+$esds-doc-tint-stack-pill-border-radius: $esds-doc-border-radius-default !default;
+$esds-doc-tint-stack-pill-font-family: $esds-doc-font-family-monospace !default;
+$esds-doc-tint-stack-pill-font-size: $esds-doc-font-size-code !default;
+$esds-doc-tint-stack-pill-text-align: center !default;
+$esds-doc-tint-stack-pill-text-color: $esds-doc-text-color-primary-on-light !default;
+$esds-doc-tint-stack-pill-space-inset: $esds-doc-space-inset-quarter-x !default;
+$esds-doc-tint-stack-pill-space-between: $esds-doc-space-generic-1-x !default;
+$esds-doc-tint-stack-pill-min-width: 4em !default;
+
+$esds-doc-tint-stack-html-example-space-inline: $esds-doc-space-generic-1-x !default;
+
+$esds-doc-tint-stack-label-max-width: none;
+
+.esds-doc-tint-stack {
+    @include esds-doc-box-sizing;
+    @include esds-doc-font-reset(
+        $font-family: $esds-doc-tint-stack-font-family);
+}
+
+.esds-doc-tint-stack__swatch {
+    align-items: center;
+    display: flex;
+    padding: $esds-doc-tint-stack-space-swatch-inset;
+}
+
+.esds-doc-tint-stack__swatch--with-border {
+    border: $esds-doc-tint-stack-swatch-border;
+}
+
+.esds-doc-tint-stack__pill {
+    background: $esds-doc-tint-stack-pill-background-color;
+    border-radius: $esds-doc-tint-stack-pill-border-radius;
+    color: $esds-doc-tint-stack-pill-text-color;
+    display: inline-block;
+    font-family: $esds-doc-tint-stack-pill-font-family;
+    font-size: $esds-doc-tint-stack-pill-font-size;
+    margin: 0 0 0 $esds-doc-tint-stack-pill-space-between;
+    min-width: $esds-doc-tint-stack-pill-min-width;
+    padding: $esds-doc-tint-stack-pill-space-inset;
+    text-align: $esds-doc-tint-stack-pill-text-align;
+}
+
+.esds-doc-tint-stack__swatch-metadata {
+    margin-left: auto;
+}
+
+.esds-doc-tint-stack__html-example {
+    margin: 0 0 0 $esds-doc-tint-stack-html-example-space-inline;
+}
+
+.esds-doc-tint-stack__label {
+    max-width: $esds-doc-tint-stack-label-max-width;
+}

--- a/docs/index.njk
+++ b/docs/index.njk
@@ -11,5 +11,6 @@
             * [with fixed header](/sink-pages/components/page-navigation-with-fixed-header.html)
             * [manually created](/sink-pages/components/page-navigation-manually-created.html)
         * [Reference Tables](/sink-pages/components/reference-tables.html)
+        * [Tint Stacks](/sink-pages/components/tint-stacks.html)
     {% endfilter %}
 {% endblock %}

--- a/docs/sink-pages/components/tint-stacks.njk
+++ b/docs/sink-pages/components/tint-stacks.njk
@@ -1,0 +1,7 @@
+{% extends "templates/sink.njk" %}
+{% block body %}
+    <h1 class="esds-doc-sink-page-header">Reference Tables Sink</h1>
+    <h1 class="esds-doc-sink-page-header">Default</h1>
+
+    {{ library.tint_stack() }}
+{% endblock body %}

--- a/docs/sink-pages/components/tint-stacks.njk
+++ b/docs/sink-pages/components/tint-stacks.njk
@@ -57,6 +57,20 @@
                     color_role: 'foreground'
                 },
                 {
+                    hex: '#888888',
+                    label: 'Border Separator, On Dark, multiple code snippets, override label color',
+                    label_color: '#FFFFFF',
+                    contrast_test_color: '#262626',
+                    code_snippets: [
+                        '$esds-doc-border-separator-on-dark',
+                        'solid 1px #888888'
+                    ],
+                    html_example: '<span style="border-bottom: solid 1px #888888; width: 180px; display: inline-block; vertical-align: middle;"></span>',
+                    show_hex: false,
+                    color_role: 'foreground',
+                    accessibility_score: false
+                },
+                {
                     hex: '#068194',
                     label: 'Special Class for this swatch',
                     class: 'my-special-tint-stack-swatch-class',

--- a/docs/sink-pages/components/tint-stacks.njk
+++ b/docs/sink-pages/components/tint-stacks.njk
@@ -2,6 +2,14 @@
 {% block body %}
     <h1 class="esds-doc-sink-page-header">Reference Tables Sink</h1>
     <h1 class="esds-doc-sink-page-header">Default</h1>
-
+    {# The class .my-special-tint-stack-swatch-class is added to one of the rows in the default swatch example #}
+    <style>
+        .my-special-tint-stack-swatch-class {
+            border: dotted 3px hotpink;
+        }
+    </style>
     {{ library.tint_stack() }}
+
+    <h1 class="esds-doc-sink-page-header">Basic Example, Only Hex Codes Provided</h1>
+    {{ library.tint_stack(swatches=['#123456', '#789ABC', '#DEF012', '#345678', '#9ABCDE']) }}
 {% endblock body %}

--- a/docs/sink-pages/components/tint-stacks.njk
+++ b/docs/sink-pages/components/tint-stacks.njk
@@ -1,15 +1,90 @@
 {% extends "templates/sink.njk" %}
 {% block body %}
     <h1 class="esds-doc-sink-page-header">Reference Tables Sink</h1>
-    <h1 class="esds-doc-sink-page-header">Default</h1>
-    {# The class .my-special-tint-stack-swatch-class is added to one of the rows in the default swatch example #}
+    <h1 class="esds-doc-sink-page-header">Default, no arguments passed, shows API doc</h1>
+    <p class="esds-doc-sink-page-copy">If <code>esds_doc.tint_stack()</code> is invoked without any arguments, this inline documentation will be shown.</p>
+
+    {{ library.tint_stack() }}
+
+    <h1 class="esds-doc-sink-page-header">Testing Multiple Option Combinations</h1>
     <style>
         .my-special-tint-stack-swatch-class {
             border: dotted 3px hotpink;
         }
     </style>
-    {{ library.tint_stack() }}
+
+
+    {{ library.tint_stack(swatches=[
+                '#656565',
+                {
+                    hex: '#123456',
+                    label: 'Mystery Color'
+                },
+                {
+                    hex: '#F57026',
+                    label: 'Orange Light, show contrast ratio',
+                    contrast_test_color: '#009f11',
+                    accessibility_score: 'AA',
+                    show_contrast_ratio: true
+                },
+                {
+                    hex: '#0A9DB3',
+                    label: 'Blue Light',
+                    code_snippet: '$esds-doc-color-blue-light'
+                },
+                {
+                    hex: '#262626',
+                    label: 'Background Color Dark',
+                    contrast_test_color: '#f3f1f1',
+                    code_snippet: '$esds-doc-background-color-dark',
+                    color_role: 'background'
+                },
+                {
+                    hex: '#000000',
+                    label: 'Text Color Primary, On White',
+                    contrast_test_color: '#ffffff',
+                    code_snippet: '$esds-doc-text-color-primary-on-white',
+                    color_role: 'foreground',
+                    show_border: true
+                },
+                {
+                    hex: '#888888',
+                    label: 'Border Separator, On Dark',
+                    contrast_test_color: '#262626',
+                    code_snippet: '$esds-doc-border-separator-on-dark',
+                    html_example: '<span style="border-bottom: solid 1px #888888; width: 180px; display: inline-block; vertical-align: middle;"></span>',
+                    show_hex: false,
+                    color_role: 'foreground'
+                },
+                {
+                    hex: '#068194',
+                    label: 'Special Class for this swatch',
+                    class: 'my-special-tint-stack-swatch-class',
+                    code_snippet: '$esds-doc-border-separator-on-dark'
+                },
+                {
+                    hex: '#FFFFFF',
+                    show_border: true
+                },
+                {
+                    hex: '#CCCCCC',
+                    contrast_test_color: '#EEEEEE',
+                    label: 'Disabled state, suppress accessibility score',
+                    accessibility_score: false
+                },
+                {
+                    hex: '#00FF90',
+                    contrast_test_color: '#FFFFFF',
+                    label: 'Failing Contrast Example'
+                }
+            ]) }}
 
     <h1 class="esds-doc-sink-page-header">Basic Example, Only Hex Codes Provided</h1>
     {{ library.tint_stack(swatches=['#123456', '#789ABC', '#DEF012', '#345678', '#9ABCDE']) }}
 {% endblock body %}
+{% block closing_body_assets %}
+    <script>
+        // Probably should have some kind of "on ready" function here
+        Esds.CodeSnippet.init();
+    </script>
+{% endblock %}

--- a/esds-build-config.js
+++ b/esds-build-config.js
@@ -65,5 +65,117 @@ module.exports = {
         env.addFilter('stripindent', function(string){
             return stripIndent(string);
         });
+
+        env.addFilter('getContrastRatioForHex', function(foregroundColor, backgroundColor) {
+            // MIT Licensed function courtesty of Lea Verou
+            // https://github.com/LeaVerou/contrast-ratio/blob/gh-pages/color.js
+            Math.round = (function(){
+                var round = Math.round;
+
+                return function (number, decimals) {
+                    decimals = +decimals || 0;
+
+                    var multiplier = Math.pow(100, decimals);
+
+                    return round(number * multiplier) / multiplier;
+                };
+            })();
+
+            // MIT Licensed functions courtesty of Qambar Raza
+            // https://github.com/Qambar/color-contrast-checker/blob/master/src/colorContrastChecker.js
+            var rgbClass = {
+                toString: function() {
+                    return '<r: ' + this.r +
+                        ' g: ' + this.g +
+                        ' b: ' + this.b +
+                        ' >';
+                }
+            };
+
+            function getRGBFromHex(color) {
+                var rgb = Object.create(rgbClass),
+                    rVal,
+                    gVal,
+                    bVal;
+
+                if (typeof color !== 'string') {
+                    throw new Error('must use string');
+                }
+
+                rVal = parseInt(color.slice(1, 3), 16);
+                gVal = parseInt(color.slice(3, 5), 16);
+                bVal = parseInt(color.slice(5, 7), 16);
+
+                rgb.r = rVal;
+                rgb.g = gVal;
+                rgb.b = bVal;
+
+                return rgb;
+            }
+
+            function calculateSRGB(rgb) {
+                var sRGB = Object.create(rgbClass),
+                    key;
+
+                for (key in rgb) {
+                    if (rgb.hasOwnProperty(key)) {
+                        sRGB[key] = parseFloat(rgb[key] / 255, 10);
+                    }
+                }
+
+                return sRGB;
+            }
+
+            function calculateLRGB(rgb) {
+                var sRGB = calculateSRGB(rgb);
+                var lRGB = Object.create(rgbClass),
+                    key,
+                    val = 0;
+
+                for (key in sRGB) {
+                    if (sRGB.hasOwnProperty(key)) {
+                        val = parseFloat(sRGB[key], 10);
+                        if (val <= 0.03928) {
+                            lRGB[key] = val / 12.92;
+                        } else {
+                            lRGB[key] = Math.pow(val + 0.055 / 1.055, 2.4);
+                        }
+                    }
+                }
+
+                return lRGB;
+            }
+
+            function calculateLuminance(lRGB) {
+                return 0.2126 * lRGB.r + 0.7152 * lRGB.g + 0.0722 * lRGB.b;
+            }
+
+            function getContrastRatio(lumA, lumB) {
+                var ratio,
+                    lighter,
+                    darker;
+
+                if (lumA >= lumB) {
+                    lighter = lumA;
+                    darker = lumB;
+                } else {
+                    lighter = lumB;
+                    darker = lumA;
+                }
+
+                ratio = (lighter + 0.05) / (darker + 0.05);
+
+                return Math.round(ratio, 1);
+            }
+
+            var color1 = getRGBFromHex(foregroundColor),
+                color2 = getRGBFromHex(backgroundColor),
+                l1RGB = calculateLRGB(color1),
+                l2RGB = calculateLRGB(color2),
+                l1 = calculateLuminance(l1RGB),
+                l2 = calculateLuminance(l2RGB);
+
+            return getContrastRatio(l1, l2);
+        });
     }
 };

--- a/esds-build-config.js
+++ b/esds-build-config.js
@@ -138,7 +138,7 @@ module.exports = {
                         if (val <= 0.03928) {
                             lRGB[key] = val / 12.92;
                         } else {
-                            lRGB[key] = Math.pow(val + 0.055 / 1.055, 2.4);
+                            lRGB[key] = Math.pow((val + 0.055) / 1.055, 2.4);
                         }
                     }
                 }

--- a/styles/esds-doc.scss
+++ b/styles/esds-doc.scss
@@ -12,5 +12,6 @@
 @import 'icon_swatch/icon_swatch';
 @import 'page_navigation/page_navigation';
 @import 'icon_swatch_grid/icon_swatch_grid';
+@import 'tint_stack/tint_stack';
 
 $doc-reference-table-background: $esds-doc-background-color-default;

--- a/templates/base.njk
+++ b/templates/base.njk
@@ -7,6 +7,7 @@
 <!doctype html>
 <html>
     <head>
+        {% block head_content_prepend %}{% endblock %}
         <link rel="stylesheet" href="/styles/dependencies/prism.css">
         <link rel="stylesheet" href="/styles/esds-doc.css">
         {% block head_assets %}{% endblock %}

--- a/templates/sink.njk
+++ b/templates/sink.njk
@@ -62,6 +62,40 @@
             text-transform: none;
             text-shadow: none;
         }
+
+        .esds-doc-sink-page-header {
+            background: transparent;
+            color: {{ esds_doc_tokens['text-color'].primary['on-white'] }};
+            font-family: {{ esds_doc_tokens.font.family['sans-serif'] | safe }};
+            font-size: 20px;
+            font-style: normal;
+            font-weight: normal;
+            letter-spacing: 0;
+            line-height: 1.2;
+            text-align: left;
+            text-indent: 0;
+            text-transform: none;
+            margin: 32px 0 16px 0;
+            padding: 0;
+            text-shadow: none;
+        }
+
+        .esds-doc-sink-page-copy {
+            background: transparent;
+            color: {{ esds_doc_tokens['text-color'].primary['on-white'] }};
+            font-family: {{ esds_doc_tokens.font.family['sans-serif'] | safe }};
+            font-size: {{ esds_doc_tokens.font.size.m }};
+            font-style: normal;
+            font-weight: normal;
+            letter-spacing: 0;
+            line-height: 1.2;
+            text-align: left;
+            text-indent: 0;
+            text-transform: none;
+            margin: 32px 0 16px 0;
+            padding: 0;
+            text-shadow: none;
+        }
     </style>
 {% endblock %}
 {% block body %}


### PR DESCRIPTION
@nathanacurtis Tint Stack Doc Component. Contrast Ratios and accessibility scores are automatically calculated. Sink page should be self-explanatory.

I'm trying a new approach for the empty state of this component. Instead of rendering a random tint stack I decided to show some API documentation instead. Hopefully this is a pattern we can start to use across all the esds-doc components.